### PR TITLE
:bug: Use getReactApplicationContext to build agent

### DIFF
--- a/android/src/main/java/com/flurry/android/reactnative/FlurryModule.java
+++ b/android/src/main/java/com/flurry/android/reactnative/FlurryModule.java
@@ -63,7 +63,7 @@ public class FlurryModule extends ReactContextBaseJavaModule {
                     public void onSessionStarted() {
                     }
                 })
-                .build(getCurrentActivity(), apiKey);
+                .build(getReactApplicationContext(), apiKey);
     }
 
     @ReactMethod


### PR DESCRIPTION
According to the [comment](https://github.com/facebook/react-native/blob/dd8f5de06fbcda45a74e63bafdc9711c12b1e07f/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.java#L34) of `getCurrentActivity` method, current  `Activity` is not suitable context for flurry agent initialization.

